### PR TITLE
增加找不到依赖的异常信息

### DIFF
--- a/packages/wepy-cli/src/compile-script.js
+++ b/packages/wepy-cli/src/compile-script.js
@@ -51,7 +51,7 @@ export default {
             ) {  
                 let pkg = this.getPkgConfig(lib);
                 if (!pkg) {
-                    throw Error('找不到模块: ' + lib);
+                    throw Error('找不到模块: ' + lib + '\n被依赖于: ' + path.join(opath.dir, opath.base));
                 }
                 let main = pkg.main || 'index.js';
                 if (pkg.browser && typeof pkg.browser === 'string') {


### PR DESCRIPTION
当找不到依赖的时候，抛出的错误信息增加依赖当前模块的模块地址。可以方便定位异常